### PR TITLE
Update the value for the backend dictionary. It now uses api rather than api-v1

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -6,11 +6,11 @@
 <configuration>
   <appSettings>
     <add key="logFileLocation" value="C:\inetpub\wwwroot\dhpr\logs\"/>
-    <add key="rdsJsonUrl" value="http://imsd.hres.ca/regContentV1/api-v1/regulatorydecision/?type=json"/>
-    <add key="ssrJsonUrl" value="http://imsd.hres.ca/regContentV1/api-v1/safetyreview/?type=json"/>
-    <add key="sbdJsonUrl" value="http://imsd.hres.ca/regContentV1/api-v1/basisdecision/?type=json"/>
-    <add key="sbdmdJsonUrl" value="http://imsd.hres.ca/regContentV1/api-v1/basisdecisionMedicalDevice/?type=json"/>
-    <add key="rdsmdJsonUrl" value="http://imsd.hres.ca/regContentV1/api-v1/regulatoryDecisionMedicalDevice/?type=json"/>
+    <add key="rdsJsonUrl" value="http://imsd.hres.ca/regContentV1/api/regulatorydecision/?type=json"/>
+    <add key="ssrJsonUrl" value="http://imsd.hres.ca/regContentV1/api/safetyreview/?type=json"/>
+    <add key="sbdJsonUrl" value="http://imsd.hres.ca/regContentV1/api/basisdecision/?type=json"/>
+    <add key="sbdmdJsonUrl" value="http://imsd.hres.ca/regContentV1/api/basisdecisionMedicalDevice/?type=json"/>
+    <add key="rdsmdJsonUrl" value="http://imsd.hres.ca/regContentV1/api/regulatoryDecisionMedicalDevice/?type=json"/>
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5">      


### PR DESCRIPTION
This webhandler points to api-content backend. In there, the routing of:
http://servername/regcontent/api-v1/controller/id   has changed to:
http://servername/regcontent/api/controller/id
(please see https://github.com/hres/api-content/commit/152ab2f36bf670747fa2737fe45a96084709c50f)