### PR TITLE
Rearrange H1 tags location so that automation script does not remove form definition.

### DIFF
--- a/regulatory-decision-summary.html
+++ b/regulatory-decision-summary.html
@@ -142,9 +142,9 @@ var autoCompletionOptions = { 'validLanguages' : 'en', };
 
     <div class="container">
             <main role="main" property="mainContentOfPage" class="container">
+                <h1 property="name" id="wb-cont">The Drug and Health Product Register</h1>
                 <div class="wb-frmvld">
                     <form name="rds" action="regulatory-decision-summary-result.html" method="get" id="rds">
-                        <h1 property="name" id="wb-cont">The Drug and Health Product Register</h1>
                              <div class="panel panel-default">
                                     <div class="panel-heading">
                                         <h2 class="panel-title">Regulatory Decision Summary Search</h2>
@@ -167,7 +167,7 @@ var autoCompletionOptions = { 'validLanguages' : 'en', };
 
                                     </div>
                               </div>
-</form>
+                    </form>
                 </div>
                 <div class="row pagedetails">
                     <div class="col-sm-5 col-xs-12 datemod">

--- a/resume-examen-innocuite.html
+++ b/resume-examen-innocuite.html
@@ -141,9 +141,9 @@ var autoCompletionOptions = { 'validLanguages' : 'fr', };
 
     <div class="container">
         <main role="main" property="mainContentOfPage" class="container">
+            <h1 property="name" id="wb-cont">Registre des médicaments et des produits de santé</h1>
             <div class="wb-frmvld">
                 <form name="rds" action="resume-examen-innocuite-resultat.html" method="get" id="ssr">
-                    <h1 property="name" id="wb-cont">Registre des médicaments et des produits de santé</h1>
 
                     <div class="panel panel-default">
                         <div class="panel-heading">

--- a/sommaire-decision-reglementaire.html
+++ b/sommaire-decision-reglementaire.html
@@ -141,9 +141,9 @@ var autoCompletionOptions = { 'validLanguages' : 'fr', };
 
     <div class="container">
         <main role="main" property="mainContentOfPage" class="container">
+            <h1 property="name" id="wb-cont">Registre des médicaments et des produits de santé</h1>
             <div class="wb-frmvld">
                 <form name="rds" action="sommaire-decision-reglementaire-resultat.html" method="get" id="rds">
-                    <h1 property="name" id="wb-cont">Registre des médicaments et des produits de santé</h1>
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <h2 class="panel-title">Sommaires des décisions réglementaires </h2>

--- a/sommaire-motif-decision.html
+++ b/sommaire-motif-decision.html
@@ -141,9 +141,9 @@ var autoCompletionOptions = { 'validLanguages' : 'fr', };
 
     <div class="container">
         <main role="main" property="mainContentOfPage" class="container">
+            <h1 property="name" id="wb-cont">Registre des médicaments et des produits de santé</h1>
             <div class="wb-frmvld">
                 <form name="sbd" action="sommaire-motif-decision-resultat.html" method="get" id="sbd">
-                    <h1 property="name" id="wb-cont">Registre des médicaments et des produits de santé</h1>
 
                     <div class="panel panel-default">
                         <div class="panel-heading">

--- a/summary-basis-decision.html
+++ b/summary-basis-decision.html
@@ -142,9 +142,9 @@ var autoCompletionOptions = { 'validLanguages' : 'en', };
 
     <div class="container">
         <main role="main" property="mainContentOfPage" class="container">
+            <h1 property="name" id="wb-cont">The Drug and Health Product Register</h1>
             <div class="wb-frmvld">
                 <form name="sbd" action="summary-basis-decision-result.html" method="get" id="sbd">
-                    <h1 property="name" id="wb-cont">The Drug and Health Product Register</h1>
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <h2 class="panel-title">Summary Basis of Decision Search</h2>

--- a/summary-safety-review.html
+++ b/summary-safety-review.html
@@ -142,9 +142,9 @@ var autoCompletionOptions = { 'validLanguages' : 'en', };
 
     <div class="container">
             <main role="main" property="mainContentOfPage" class="container">
+                <h1 property="name" id="wb-cont">The Drug and Health Product Register</h1>
                 <div class="wb-frmvld">
                     <form name="rds" action="summary-safety-review-result.html" method="get" id="rds">
-                        <h1 property="name" id="wb-cont">The Drug and Health Product Register</h1>
 
                                 <div class="panel panel-default">
                                     <div class="panel-heading">


### PR DESCRIPTION
Currently the process of converting the regcontent HTML to PHP is done with automation script. Part of the script logic is to remove everything above the H1 and apply it's own header.

However, for six files, a form (and div) tag is defined before the h1 which means they get clipped. This means someone has to review and undo the change which is error prone and takes time.

This PR is to change the six HTML files so the H1 tag is located earlier so nothing gets clipped.